### PR TITLE
Add responses to sentence triggers

### DIFF
--- a/source/_docs/automation/trigger.markdown
+++ b/source/_docs/automation/trigger.markdown
@@ -928,6 +928,8 @@ automation:
       command:
         - "[it's ]party time"
         - "happy (new year|birthday)"
+      response_success: "Let there be party"
+      response_error: "You cannot party right now"
 ```
 
 The sentences matched by this trigger will be:
@@ -955,6 +957,31 @@ For example, the sentence `play {album} by {artist}` will match "play the white 
 
 Wildcards will match as much text as possible, which may lead to surprises: "play day by day by taken by trees" will match `album` as "day" and `artist` as "day by taken by trees".
 Including extra words in your template can help: `play {album} by artist {artist}` can now correctly match "play day by day by artist taken by trees".
+
+### Responses
+
+There are two config options which dictate what Assist will respond with when a matching sentence triggers the automation.
+
+`response_success` is the response phrase in case all of the automation steps have run successfully. You can use Jinja2 [template syntax](/docs/configuration/templating/) to include any variables set inside the automation. `response_error` is passed when an automation step fails or if any error prevents the automation from running. `response_error` is just a static text and does not accept templates.
+
+```yaml
+automation:
+  trigger:
+    - platform: conversation
+      command: "what's on my calendar today"
+      response_success: "{{ my_events.events | map(attribute='summary') | join(', ') }}"
+      response_error: "Sorry, I can't get your calendar events right now"
+  action:
+    - service: calendar.list_events
+      data:
+        duration:
+          hours: 24
+          minutes: 0
+          seconds: 0
+      target:
+        entity_id: calendar.my_calendar
+      response_variable: my_events
+```
 
 ## Multiple triggers
 


### PR DESCRIPTION
## Proposed change
<!-- 
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the 
    additional information section.
-->
Allow the customization of the response Assist (`default_agent`) offers when sentence triggers are used.

Until now, sentence triggers could only be used to "do" things - they would start an automation and just reply "Done" at the end. The 2 problems with this approach are:
1. this doesn't make sense if the sentence was in a different language than English
1. there was no way of getting information from HA and relaying it back to the user via sentence triggers

With this PR, you can customize the responses that the user can get back in Assist:
- if the automation was successful, he can define a template using all of the `run_variables` that were set during the automation run
- if the automation doesn't run, he can set an error message


## Type of change
<!--
    What types of changes does your PR introduce to our documentation/website?
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR.
-->

- [ ] Spelling, grammar or other readability improvements (`current` branch).
- [ ] Adjusted missing or incorrect information in the current documentation (`current` branch).
- [ ] Added documentation for a new integration I'm adding to Home Assistant (`next` branch).
  - [ ] I've opened up a PR to add logo's and icons in [Brands repository](https://github.com/home-assistant/brands).
- [x] Added documentation for a new feature I'm adding to Home Assistant (`next` branch).
- [ ] Removed stale or deprecated documentation.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- Link to parent pull request in the codebase: https://github.com/home-assistant/core/pull/99870
- Link to parent pull request in the Brands repository: 
- This PR fixes or closes issue: fixes https://github.com/home-assistant/intents/issues/1450

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] This PR uses the correct branch, based on one of the following:
  - I made a change to the existing documentation and used the `current` branch.
  - I made a change that is related to an upcoming version of Home Assistant and used the `next` branch.
- [ ] The documentation follows the Home Assistant documentation [standards].

[standards]: https://developers.home-assistant.io/docs/documenting/standards
